### PR TITLE
Removed 'how Haskell works' comment

### DIFF
--- a/src/Remnant.hs
+++ b/src/Remnant.hs
@@ -34,10 +34,8 @@ reduceRemnantUsingSource previousRemnant source =
 -}
 reduce :: Remnant -> Source -> Target -> Remnant
 reduce remnant source target
-   {-- | any (elem NoOverlap) allR = [target] -}
    | NoOverlap `elem` allR = [target]
    | all (== OverlapsTarget) allR = []
-   {-- had to change the otherwise results as it was the same as all OverlapsTarget -}
    | otherwise = [Target { x = TrgSeg (-1, -1), y = TrgSeg (-1, -1), z = TrgSeg (-1, -1) }]
    where
       xr = compareSegments (xSrc source) (x target)

--- a/test/RemnantSpec.hs
+++ b/test/RemnantSpec.hs
@@ -24,7 +24,6 @@ target = Target { x = TrgSeg (30, 40), y = TrgSeg (30, 40), z = TrgSeg (30, 40) 
 
 remnantSpec =
   describe "reduce" $ do
-    -- it's a "do block" so "let" is OK! but no need for "in"!
     let target2 = Target { x = TrgSeg (15, 17), y = TrgSeg (15, 17), z = TrgSeg (15, 17) }
     it "source and target don't overlap" $ do
       result


### PR DESCRIPTION
Hey, thanks for the comment on `let` not needing `in` when in `do` statement; you are correct: I had forgotten that.

All I did was remove the comment. (As well as 2 other explanatory comments.)

This PR is on your `spec-tests` branch.  After merging it, you should merge your updated `spec-tests` to `main`.

You PASS your quiz! Congratulations!